### PR TITLE
test_utils_public_signatures test fails with Python 3.11

### DIFF
--- a/os_win/tests/unit/test_utilsfactory.py
+++ b/os_win/tests/unit/test_utilsfactory.py
@@ -186,8 +186,8 @@ class TestHyperVUtilsFactory(test_base.OsWinBaseTestCase):
                          "public methods not listed in class %s" % baseclass)
 
         for name in sorted(implmethods.keys()):
-            baseargs = inspect.getargspec(basemethods[name])
-            implargs = inspect.getargspec(implmethods[name])
+            baseargs = inspect.getfullargspec(basemethods[name])
+            implargs = inspect.getfullargspec(implmethods[name])
 
             self.assertEqual(baseargs, implargs,
                              "%s args don't match class %s" %


### PR DESCRIPTION
Since Python 3.11, getargspec attribute was removed for inspect module.

```
$> python3.11 -m unittest tests.unit.test_utilsfactory.TestHyperVUtilsFactory.test_utils_public_signatures
E
======================================================================
ERROR: test_utils_public_signatures (tests.unit.test_utilsfactory.TestHyperVUtilsFactory.test_utils_public_signatures)
tests.unit.test_utilsfactory.TestHyperVUtilsFactory.test_utils_public_signatures
----------------------------------------------------------------------
testtools.testresult.real._StringException: Traceback (most recent call last):
  File "/python-os-win-5.7.1/os_win/tests/unit/test_utilsfactory.py", line 167, in test_utils_public_signatures
    self.assertPublicAPISignatures(base_class, tested_class)
  File "/python-os-win-5.7.1/os_win/tests/unit/test_utilsfactory.py", line 189, in assertPublicAPISignatures
    baseargs = inspect.getargspec(basemethods[name])
               ^^^^^^^^^^^^^^^^^^
AttributeError: module 'inspect' has no attribute 'getargspec
```

Kind Regards